### PR TITLE
Allow for resinOS releases containing the '+' character

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ function get_header_paths()
 		if [[ "$key" = 'Key' ]]; then
 			last_marker=$val
 
-			[[ "$val" =~ $pattern ]] || continue
+			[[ "$val" =~ $(echo "$pattern" | sed -e 's/+/\\+/g') ]] || continue
 
 			local device="${BASH_REMATCH[1]}"
 			local version="${BASH_REMATCH[2]}"
@@ -108,7 +108,7 @@ function get_and_build()
 	tmp_path=$(mktemp --directory)
 	push $tmp_path
 
-	if ! wget "$url"; then
+	if ! wget $(echo "$url" | sed -e 's/+/%2B/g'); then
 		pop
 		rm -rf "$tmp_path"
 


### PR DESCRIPTION
in the release version name (e.g. 2.0.6+rev1.prod)

The first change is related to the fact that '+' is a special char
in a regex and we need to escape it to actually use it as the '+' char.

The second change addresses the fact the AWS S3 treats '+' in the
path section of an URL as a space character. In our case it is part
of a actual directory name in the URL's path part so we need S3 to
interpret the '+' char as the actual '+' char and not the space char,
therefore we encode it here using the equivalent hex code '%2B' used
for the '+' character.

Signed-off-by: Florin Sarbu <florin@resin.io>