### PR TITLE
build.sh: Fix aws cli rework

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ function get_header_paths()
 # List available devices and versions.
 function list_versions()
 {
-	list_kernels=$(/root/.local/bin/aws s3api list-objects --no-sign-request --bucket $s3_bucket  --output text  --query 'Contents[]|[?contains(Key, `kernel`)]|[?contains(Key,`images`)]' | cut -f2)
+	list_kernels=$(aws s3api list-objects --no-sign-request --bucket $s3_bucket  --output text  --query 'Contents[]|[?contains(Key, `kernel`)]|[?contains(Key,`images`)]' | cut -f2)
 
 	while read -r line; do
 		var1=$(echo "$line" | cut -f1 -d/)


### PR DESCRIPTION
We now install aws cli the right way using apt-get. Change this line
to use aws cli instead of the pip install in the user path where the
cli is not installed anymore.

Change-type: patch
Changelog-entry: Fix for aws cli when ./build.sh --list is run
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>