### PR TITLE
Fixes for compiling modules from kernel sources

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM balenalib/%%RESIN_MACHINE_NAME%%-debian
 
-RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev awscli
+RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev awscli bc flex libssl-dev
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 

--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,15 @@ function get_and_build()
 		return
 	fi
 
-	if ! tar -xf $filename --strip 1; then
+	strip_depth=1
+	if [[ $filename == *"source"* ]]; then
+		# The kernel source tarball has a leading ./ as well. Increase strip_depth
+		strip_depth=2
+		# Change output_dir to avoid overwriting the modules compiled from just the headers tarball
+		output_dir="${output_dir}_from_src"
+	fi
+
+	if ! tar -xf $filename --strip $strip_depth; then
 		pop
 		rm -rf "$tmp_path"
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 files_url='https://files.balena-cloud.com' # URL exporting S3 XML
 s3_xml=$(curl -L -s $files_url)
 


### PR DESCRIPTION
We now ship the complete kernel source from v2.31 onwards.

Here are a few fixes that enable