### PR TITLE
run.sh: Improve script to load multiple modules if available

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 OS_VERSION=$(echo $RESIN_HOST_OS_VERSION | cut -d " " -f 2)
-mod_dir="example_module_${RESIN_DEVICE_TYPE}_${OS_VERSION}*"
+echo "OS Version is $OS_VERSION"
 
-insmod $mod_dir/hello.ko
-lsmod | grep hello
-rmmod hello
-echo done!
+mod_dir="example_module_${RESIN_DEVICE_TYPE}_${OS_VERSION}*"
+for each in $mod_dir; do
+	echo Loading module from $each
+	insmod $each/hello.ko
+	lsmod | grep hello
+	rmmod hello
+done
 
 while true; do
 	sleep 60


### PR DESCRIPTION
We are currently shipping the kernel source tarball and a kernel header
tarball. build.sh build kernel modules using both tarballs and places
them in seperate folders.

But run.sh only inserts one module to test. Add a loop so that it
tries to load modules from multiple module folders if found

Change-type: patch
Changelog-entry: Improve run.sh to load modules from multiple folder
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>