### PR TITLE
Merge various workarounds into one script

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM balenalib/%%RESIN_MACHINE_NAME%%-debian
 
-RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev awscli bc flex libssl-dev
+RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev awscli bc flex libssl-dev python
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 

--- a/build.sh
+++ b/build.sh
@@ -92,13 +92,6 @@ function get_and_build()
 	tmp_path=$(mktemp --directory)
 	push $tmp_path
 
-	# Workaround for the nuc image. Tools compiled expecting /lib/ld-linux-x86-64.so.2 while it is in /lib64
-	if [ -f /lib64/ld-linux-x86-64.so.2 ]; then
-		if [ ! -f /lib/ld-linux-x86-64.so.2 ]; then
-			ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2
-		fi
-	fi
-
 	if ! wget $(echo "$url" | sed -e 's/+/%2B/g'); then
 		pop
 		rm -rf "$tmp_path"
@@ -122,6 +115,11 @@ function get_and_build()
 		err "ERROR: $path: Unable to extract $tmp_path/$filename, skipping."
 		return
 	fi
+
+	# Kernel headers for some devices need a few workarounds to build. These workarounds either effect
+	# the build environment. Or the headers were incorrectly generated during the os build stage.
+	# The full kernel source tarball available from v2.30+ should always work.
+	/usr/src/app/workarounds.sh $device $version $output_dir
 
 	# Check if we have fetched the kernel_source tarball
 	if [[ $filename == *"source"* ]]; then

--- a/workarounds.sh
+++ b/workarounds.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o errexit
+
+device="$1"
+version="$2"
+dest_folder="/usr/src/app/$3"
+
+if [[ "$device" == asus-tinker* ]] ; then
+	echo Workaround tinkerboard
+	# Specific for the Asus Tinkerboard
+	# Check for config option CONFIG_ARCH_ROCKCHIP and
+	# if set remove the line that sets the default ARCH
+	# inside the Makefile
+	if grep -q "CONFIG_ARCH_ROCKCHIP=y" .config; then
+		sed -i '/?= arm64/d' Makefile
+	fi
+fi
+
+if [[ "$device" == beagle* ]] ; then
+	echo Workaround bbb
+	wget https://raw.githubusercontent.com/beagleboard/linux/4.14/arch/arm/kernel/module.lds -O "$PWD"/arch/arm/kernel/module.lds
+fi
+
+if [[ "$device" == intel-nuc ]] ; then
+	echo Workaround nuc
+	# Workaround for the nuc image. Tools compiled expecting /lib/ld-linux-x86-64.so.2 while it is in /lib64
+	if [ -f /lib64/ld-linux-x86-64.so.2 ]; then
+		if [ ! -f /lib/ld-linux-x86-64.so.2 ]; then
+			ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2
+		fi
+	fi
+fi
+
+if [[ "$device" == ts4900 ]] ; then
+	echo Workaround ts4900
+	# Workaround for the ts4900 to deal with unknown relocation error
+	# when build OOT modules
+	if grep -q "ts4900" ./arch/arm/boot/dts/Makefile; then
+		sed -i 's/^CFLAGS_MODULE \+=/CFLAGS_MODULE += -fno-pic/g' Makefile
+        fi
+fi


### PR DESCRIPTION
We have been keeping the workarounds in separate branches but that is
harder for testing and tricky to manage. Fixes to master dont reach the
branches.

This PR adds a workaround.sh file which is called during the build.
Workarounds for various devices go here.
