### PR TITLE
Workaround for up-board

### DIFF
--- a/workarounds.sh
+++ b/workarounds.sh
@@ -40,3 +40,10 @@ if [[ "$device" == ts4900 ]] ; then
 		sed -i 's/^CFLAGS_MODULE \+=/CFLAGS_MODULE += -fno-pic/g' Makefile
         fi
 fi
+
+if [[ "$device" == up-board ]] ; then
+	echo Workaround up-board
+	# Workaround for the up-board to re-compile the module generating tools with flags
+	# specific to the builder server CPU arch
+	make modules_prepare
+fi


### PR DESCRIPTION
This workaround re-compiles the the module generating tools with flags
specific to the builder server CPU arch.

Otherwise, the tools can't be executed on the server because they are
compiled with flags specific to up-board's CPU version.

This error is avoided by applying the workaround:
" /bin/sh: 1: scripts/basic/fixdep: not found"

Signed-off-by: Sebastian Panceac <sebastian@balena.io>