### PR TITLE
Improve nuc workaround

### DIFF
--- a/workarounds.sh
+++ b/workarounds.sh
@@ -6,6 +6,13 @@ device="$1"
 version="$2"
 dest_folder="/usr/src/app/$3"
 
+# Workaround for x86_64 images. Tools compiled expecting /lib/ld-linux-x86-64.so.2 while it is in /lib64 in Debian
+if [ -f /lib64/ld-linux-x86-64.so.2 ]; then
+	if [ ! -f /lib/ld-linux-x86-64.so.2 ]; then
+		ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2
+	fi
+fi
+
 if [[ "$device" == asus-tinker* ]] ; then
 	echo Workaround tinkerboard
 	# Specific for the Asus Tinkerboard
@@ -20,16 +27,6 @@ fi
 if [[ "$device" == beagle* ]] ; then
 	echo Workaround bbb
 	wget https://raw.githubusercontent.com/beagleboard/linux/4.14/arch/arm/kernel/module.lds -O "$PWD"/arch/arm/kernel/module.lds
-fi
-
-if [[ "$device" == intel-nuc ]] ; then
-	echo Workaround nuc
-	# Workaround for the nuc image. Tools compiled expecting /lib/ld-linux-x86-64.so.2 while it is in /lib64
-	if [ -f /lib64/ld-linux-x86-64.so.2 ]; then
-		if [ ! -f /lib/ld-linux-x86-64.so.2 ]; then
-			ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2
-		fi
-	fi
 fi
 
 if [[ "$device" == ts4900 ]] ; then


### PR DESCRIPTION
We have this in place for just nuc but this issue affects all x86_64
based devices. Apply this innocous workaround for all devices similar
to what we do in meta-balena.

This issue stems from the difference in baselib directory between
Debian and balenaOS for ld-linux-x86-64.so.2.

Change-type: patch
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>