### PR TITLE
build.sh: Change path for the headers tar.gz

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ function get_header_paths()
 	list_kernels=$(aws s3api list-objects --no-sign-request --bucket $s3_bucket  --output text  --query 'Contents[]|[?contains(Key, `kernel`)]' | cut -f2)
 
 	while read -r line; do
-		if echo "$line" | grep -q "images/$dev_pat/$ver_pat"; then
+		if echo "$line" | grep -e "^\(esr\-\)\?images\/" | grep -q "$dev_pat/$ver_pat"; then
 			device=$(echo "$line" | cut -f2 -d/)
 			version=$(echo "$line" | cut -f3 -d/)
 			echo "$line"
@@ -79,11 +79,11 @@ function list_versions()
 function get_and_build()
 {
 	local path="$1"
-	local pattern="^images/(.*)/(.*)/"
+	local pattern="^(esr-)?images/(.*)/(.*)/"
 	[[ "$path" =~ $pattern ]] || fatal "Invalid path '$path'?!"
 
-	local device="${BASH_REMATCH[1]}"
-	local version="${BASH_REMATCH[2]}"
+	local device="${BASH_REMATCH[2]}"
+	local version="${BASH_REMATCH[3]}"
 	local output_dir="${module_dir}_${device}_${version}"
 
 	filename=$(basename $path)


### PR DESCRIPTION
Change the test to add ESR kernel_modules_headers
archives.
Include matching of the esr-images directory otherwise it will not
match against the key from the xml file on S3:
Invalid path
'esr-images/.../2019.10.1.prod/kernel_modules_headers.tar.gz'?!

Changelog-entry: Update validator for ESR release of the headers S3 path
Signed-off-by: Vicentiu Galanopulo <viceniu@balena.io>