### PR TITLE
Update project to build for newer balenaOS

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,10 +1,14 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
 
-RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev awscli bc flex libssl-dev python bison
+RUN install_packages curl wget build-essential libelf-dev awscli bc flex libssl-dev python bison
+
+# install gcc 10
+RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && install_packages gcc-9 libc6-dev
+
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 
-ENV VERSION '2.47.0+rev1.prod 2.50.4+rev1.prod'
+ENV VERSION '2.73.1+rev1.prod'
 RUN BALENA_MACHINE_NAME=%%BALENA_MACHINE_NAME%% ./build.sh build --device %%BALENA_MACHINE_NAME%% --os-version "$VERSION" --src example_module
 
 CMD ./run.sh

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,14 +1,23 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3-bullseye
 
-RUN install_packages curl wget build-essential libelf-dev awscli bc flex libssl-dev python bison
+RUN install_packages \
+    curl \
+    wget \
+    build-essential \
+    libelf-dev \
+    awscli \
+    bc \
+    flex \
+    libssl-dev \
+    bison
 
-# install gcc 10
-RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && install_packages awscli python3-yaml gcc-9 libc6-dev
 
 COPY . /usr/src/app
+
 WORKDIR /usr/src/app
 
-ENV VERSION '2.73.1+rev1.prod'
+ENV VERSION '2.88.4.prod'
+
 RUN BALENA_MACHINE_NAME=%%BALENA_MACHINE_NAME%% ./build.sh build --device %%BALENA_MACHINE_NAME%% --os-version "$VERSION" --src example_module
 
 CMD [ "/usr/src/app/run.sh" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -3,7 +3,7 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
 RUN install_packages curl wget build-essential libelf-dev awscli bc flex libssl-dev python bison
 
 # install gcc 10
-RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && install_packages gcc-9 libc6-dev
+RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && install_packages awscli python3-yaml gcc-9 libc6-dev
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app
@@ -11,4 +11,4 @@ WORKDIR /usr/src/app
 ENV VERSION '2.73.1+rev1.prod'
 RUN BALENA_MACHINE_NAME=%%BALENA_MACHINE_NAME%% ./build.sh build --device %%BALENA_MACHINE_NAME%% --os-version "$VERSION" --src example_module
 
-CMD ./run.sh
+CMD [ "/usr/src/app/run.sh" ]


### PR DESCRIPTION
Some recent balenaOS images using kernel 5.10 and gcc 9.3.0
are unable to compile kernel modules using gcc 8 in debian buster.

`gcc: error: unrecognized command line option '-mstack-protector-guard=sysreg'`

Resolves: https://github.com/balena-os/kernel-module-build/issues/37
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>