### PR TITLE
Dockerfile.template: Update base image to ubuntu impish

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3-bullseye
+FROM balenalib/%%BALENA_MACHINE_NAME%%-ubuntu-python:3.8.13-impish
 
 RUN install_packages \
     curl \


### PR DESCRIPTION
Building for device types with newer kernel versions on bullseye fails with:
```
scripts/basic/fixdep: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by scripts/basic/fixdep)
scripts/basic/fixdep: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by scripts/basic/fixdep)
```
Fixes #42

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>