### PR TITLE
Add balena Cloud builder example

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,23 +1,59 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-ubuntu-python:3.8.13-impish
+FROM ubuntu:jammy-20220531 as kernel-build
 
-RUN install_packages \
-    curl \
-    wget \
-    build-essential \
-    libelf-dev \
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+RUN apt-get update && \
+    apt-get install -y \
     awscli \
     bc \
+    bison \
+    build-essential \
+    curl \
     flex \
+    git \
+    libelf-dev \
     libssl-dev \
-    bison
-
-
-COPY . /usr/src/app
+    wget
 
 WORKDIR /usr/src/app
 
-ENV VERSION '2.88.4.prod'
+# Clones the kernel builder repository
+RUN git clone https://github.com/balena-os/kernel-module-build.git .
 
-RUN BALENA_MACHINE_NAME=%%BALENA_MACHINE_NAME%% ./build.sh build --device %%BALENA_MACHINE_NAME%% --os-version "$VERSION" --src example_module
+# You can switch to a specific commit of the kernel builder if you want to ensure consistent builds
+# git reset --hard f889851c5d00890b51b27c63eaa59a976063265a
 
-CMD [ "/usr/src/app/run.sh" ]
+# Copy your kernel source from your local build context to the build directory
+COPY example_module .
+
+# Set the name of the directory where you have copied your kernel source in the step above
+ENV MOD_DIR "example_module"
+
+# Set the balena OS version you intend to use
+ENV OS_VERSION '2.99.27'
+
+# Start the build
+RUN BALENA_MACHINE_NAME=%%BALENA_MACHINE_NAME%% ./build.sh build --device %%BALENA_MACHINE_NAME%% --os-version "$OS_VERSION" --src "$MOD_DIR"
+
+
+FROM alpine
+
+# Set the directory where you would like your kernel source
+ARG MOD_PATH=/etc/output
+ENV MOD_DIR example_module
+
+# Required for access when the container starts
+ENV MOD_PATH="$MOD_PATH"
+
+# Copy the built kernel module into your app
+COPY --from=kernel-build /usr/src/app/output/ "$MOD_PATH"
+
+# Copy the startup script for loading the modules
+COPY --from=kernel-build /usr/src/app/run.sh /usr/src/app/run.sh
+
+# Start the script that loads the modules.
+ENTRYPOINT ["sh", "/usr/src/app/run.sh"]
+
+# Run your usual service with CMD
+CMD exec /bin/sh -c "trap : TERM INT; sleep 9999999999d & wait"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-This is an example of building an out-of-tree kernel module using module headers
-provided for balena devices.
+# Kernel Module Build
 
-Make sure you change to the desired balenaOS version in the [Dockerfile.template][Dockerfile template] and commit the change before you start building this project.
+This is an example of building an out-of-tree kernel module using module headers provided for balena devices.
 
-#### Usage
+### Usage
+
+`Dockerfile` demonstrates how to use a multistage build in the balena Cloud to build your kernel and copy it in to your application container. Make sure you change to the desired balenaOS version by amending the environment variables in the Dockerfile.
+
+#### Build options
+
 ```
 usage: build.sh [build|list] [options]
 
@@ -21,5 +25,3 @@ examples:
   ./build.sh list
   ./build.sh build --device intel-nuc --os-version '2.48.0+rev3.prod 2.47.1+rev1.prod' --src example_module
 ```
-
-[Dockerfile template]: https://github.com/balena-io-playground/kernel-module-build/blob/master/Dockerfile.template#L6

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 
@@ -60,7 +60,7 @@ function get_header_paths()
 {
 	local dev_pat="${1:-.*}"
 	local ver_pat="${2:-.*}"
-	list_kernels=$(aws s3api list-objects --no-sign-request --bucket $s3_bucket  --output text  --query 'Contents[]|[?contains(Key, `kernel`)]' | cut -f2)
+	list_kernels=$(aws s3api list-objects-v2 --no-sign-request --bucket $s3_bucket  --output text  --query 'Contents[]|[?contains(Key, `kernel`)]' | cut -f2)
 
 	local found=
 	while read -r line; do
@@ -76,7 +76,7 @@ function get_header_paths()
 # List available devices and versions.
 function list_versions()
 {
-	list_kernels=$(aws s3api list-objects --no-sign-request --bucket $s3_bucket  --output text  --query 'Contents[]|[?contains(Key, `kernel`)]|[?contains(Key,`images`)]' | cut -f2)
+	list_kernels=$(aws s3api list-objects-v2 --no-sign-request --bucket $s3_bucket  --output text  --query 'Contents[]|[?contains(Key, `kernel`)]|[?contains(Key,`images`)]' | cut -f2)
 
 	while read -r line; do
 		var1=$(echo "$line" | cut -f1 -d/)

--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,13 @@
-#!/bin/bash
-
+#!/usr/bin/env sh
 OS_VERSION=$(echo "$BALENA_HOST_OS_VERSION" | cut -d " " -f 2)
 echo "OS Version is $OS_VERSION"
 
-cd output
-mod_dir="example_module_${BALENA_DEVICE_TYPE}_${OS_VERSION}*"
-for each in $mod_dir; do
-	echo Loading module from "$each"
-	insmod "$each/hello.ko"
-	lsmod | grep hello
-	rmmod hello
+mod_dir="${MOD_PATH}/${MOD_DIR}_${BALENA_DEVICE_TYPE}_${OS_VERSION}"
+
+for file in "$mod_dir"/*.ko ; do
+	echo Loading module from "$file"
+    insmod "$file"
 done
 
-while true; do
-	sleep 60
-done
+# Run the passed CMD as PID 1
+exec "$@"

--- a/workarounds.sh
+++ b/workarounds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 


### PR DESCRIPTION
This PR updates the example to be one related to using the balena Cloud builders and deploying to fleets.

There is also an update to list-objects-v2 for the aws cli as I found it be be significantly faster (listing down from 5 minutes to 2 minutes on my system).

Originally discussed in https://github.com/balena-os/kernel-module-build/pull/46 but resubmitted here to overcome a test issue with external repos as PR sources. 

Change-type: patch