### PR TITLE
Add compatibility with UDEV=on

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,10 +4,14 @@ echo "OS Version is $OS_VERSION"
 
 mod_dir="${MOD_PATH}/${MOD_DIR}_${BALENA_DEVICE_TYPE}_${OS_VERSION}"
 
-for file in "$mod_dir"/*.ko ; do
+# NOTE: some modules need to be loaded in a specific order
+# if that's the case, replace the loop below with a list of
+# `insmod $mod_dir/<module>.ko` commands in the right order
+for file in "$mod_dir"/*.ko; do
 	echo Loading module from "$file"
-    insmod "$file"
+	insmod "$file"
 done
 
+# Pass the CMD to the entrypoint from the base images
 # Run the passed CMD as PID 1
-exec "$@"
+exec /usr/bin/entry.sh "$@"


### PR DESCRIPTION
Some kernel modules may create devices under `/dev`, in which case the recommended way to show those devices in the container is to set `UDEV=on`. Since the dockerfile in this example repo replaces the entrypoint, then that feature won't be available by default.

This updates the run.sh entrypoint to pass the CMD to `/usr/bin/entry.sh` to make it compatible with that feature.

It also adds a disclaimer about modules that need to load in order.

Change-type: minor