### PR TITLE
Update Nvidia example to be compatible with BalenaOS v5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Kernel Module Builder
+# Nvidia Kernel Module Builder
 
-Provides an example of a multi-container application with a service that builds
-an out-of-tree kernel module, loads it and runs it alongside an example service.
+Provides a multi-container application with a service that builds
+an out-of-tree Nvidia kernel module, loads it and runs it alongside an example service.
 
 * The `load` service builds the kernel module source located in `module/src`
   using module headers provided for balena devices using a multi-stage build
@@ -21,12 +21,10 @@ balena push <fleet>
 
 The device type will be automatically retrieved from the specified fleet.
 
-## Customization
+## Note
+Once pushed, the Nvidia drivers will be loaded.
+To confirm they are properly working you can SSH to the any device and run:
+`lsmod | grep nvidia`
 
-* Replace the `OS_VERSION` argument in the `load` service in the
-  `docker-compose.yml` file to match the balenaOS version of the target device.
-
-* Replace the contents of the `module/src` directory with the module source to
-  build.
-
-* Replace the `check` service by your own service.
+To push this container again you will first need to unload any previous module:
+`rmmod nvidia_drm nvidia_uvm nvidia_modeset nvidia_peermem nvidia`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       dockerfile: Dockerfile.template
       args:
         # Modify to the desired balenaOS version
-        OS_VERSION: 2.108.27
+        OS_VERSION: 5.3.27+rev1
         # Modify to the desired Nvidia GPU driver version and architecture
-        DRIVER_VERSION: 535.54.03
+        DRIVER_VERSION: "550.100"
         DRIVER_ARCH: x86_64
     privileged: true
     restart: on-failure

--- a/module/Dockerfile.template
+++ b/module/Dockerfile.template
@@ -11,7 +11,8 @@ RUN apt-get update && \
     libelf-dev \
     libssl-dev \
     kmod \
-    wget
+    wget \
+    bc
 
 WORKDIR /usr/src/app
 

--- a/module/build.sh
+++ b/module/build.sh
@@ -59,7 +59,13 @@ build_module() {
 	make -C "${headers_dir}" modules_prepare
 	wget --quiet https://us.download.nvidia.com/XFree86/Linux-${DRIVER_ARCH}/${DRIVER_VERSION}/${nvidia_installer}
 	chmod a+x "${nvidia_installer}"
-	./${nvidia_installer} --silent --kernel-source-path "${headers_dir}"
+
+	skip_module_load_option=""
+	if ./${nvidia_installer} --advanced-options | grep -ic -- "--skip-module-load"; then
+		skip_module_load_option="--skip-module-load"
+	fi
+	./${nvidia_installer} --silent --kernel-source-path "${headers_dir}" ${skip_module_load_option}
+
 	mkdir -p "${output_dir}"
 	cp /lib/modules/*/video/* ${output_dir}
 	rm -rf "$headers_dir"

--- a/module/load.sh
+++ b/module/load.sh
@@ -2,17 +2,45 @@
 OS_VERSION=$(echo "$BALENA_HOST_OS_VERSION" | cut -d " " -f 2)
 echo "OS Version is $OS_VERSION"
 
+# Unload existing modules that could interfer
+remove_module_if_loaded() {
+	local module="$1"
+	if lsmod | grep -q "$module"; then
+		echo "Removing module $module"
+		rmmod "$module"
+	fi
+}
+
+remove_module_if_loaded hello
+remove_module_if_loaded nouveau
+remove_module_if_loaded nvidiafb
+
 # NOTE: some modules need to be loaded in a specific order
-# if that's the case, replace the loop below with a list of
-# `insmod $mod_dir/<module>.ko` commands in the right order
+# Update bellow logic if needed
+nvidia_module="nvidia.ko"
+drm_module="nvidia-drm.ko"
+
+# Load nvidia first
+module_path="$MOD_PATH/$nvidia_module"
+if [ -f "$module_path" ]; then
+    echo "Loading module from $module_path"
+    insmod "$module_path"
+fi
+
+# Load the other modules
 for file in "$MOD_PATH"/*.ko; do
-	if lsmod | grep -q hello; then
-		rmmod hello
-	fi
-	# remove the nouveau module if it's loaded
-	if lsmod | grep -q nouveau; then
-		rmmod nouveau
-	fi
-	echo Loading module from "$file"
-	insmod "$file"
+    module=$(basename "$file")
+    if [ "$module" = $nvidia_module ] || [ "$module" = $drm_module ]; then
+        continue
+    fi
+    
+    echo "Loading module from $file"
+    insmod "$file"
 done
+
+# Load nvidia_drm last
+module_path="$MOD_PATH/$drm_module"
+if [ -f "$module_path" ]; then
+    echo "Loading module from $module_path"
+    insmod "$module_path"
+fi


### PR DESCRIPTION
The example projet to build Nvidia kernel module was outdated.
This pull request provides fixes and was tested with the latest BalenaOS v5.3.

Patches:
- Add missing `bc` dependency
- Fix the module trying to load during installation and before existing kernel modules are unloaded (using the --skip-module-load option)
- Load "nvidia.ko" module first and "nvidia-drm.ko" module last
- Bump Nvidia driver version to 550.100 (latest stable)