### PR TITLE
Allow to provide header files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ The device type will be automatically retrieved from the specified fleet.
   build.
 
 * Replace the `check` service by your own service.
+
+* Optionally, kernel header files can be provided under
+  `module/kernel-module-headers.tar.gz`. This is only required for
+  private device types that do not have the header files publicly available.

--- a/module/Dockerfile.template
+++ b/module/Dockerfile.template
@@ -23,7 +23,7 @@ COPY src $SRC_DIR/
 COPY include include/
 COPY build.sh .
 COPY load.sh .
-COPY workarounds.sh .
+COPY workarounds.sh kernel_modules_headers.tar.gz* ./
 RUN ./build.sh -s %%BALENA_MACHINE_NAME%% -v $OS_VERSION -i $SRC_DIR -o $OUT_DIR
 
 FROM alpine


### PR DESCRIPTION
For use cases where the header files are not publicly available, like private device types, allow for the headers to be provided.

Change-type: patch