### PR TITLE
module: Switch to using an Alpine base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile.template
       args:
         # Modify to the desired balenaOS version
-        OS_VERSION: 2.108.27
+        OS_VERSION: 6.10.9
     privileged: true
     restart: on-failure
   check:

--- a/module/Dockerfile.template
+++ b/module/Dockerfile.template
@@ -1,17 +1,17 @@
-FROM ubuntu:jammy-20220531 as kernel-build
+FROM alpine:20251224 as kernel-build
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apk add --no-cache \
     bison \
-    build-essential \
+    build-base \
     flex \
-    libelf-dev \
-    libssl-dev \
+    elfutils-dev \
+    openssl-dev \
     bc \
-    wget
+    wget \
+    bash
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The Ubuntu base image no longer works for RaspberryPi builds, and the Dockerhub page does not mention armv32v6 as supported. It is possible this may have been dropped because builds passed previously, but as of today `RUN echo test` in a Ubuntu base image build on a RaspberryPi fails.

We also notice the following error when issuing a build on the RPI with the Ubuntu base image:

    [Warning] The requested image's platform (linux/arm/v7)
    does not match the detected host platform (linux/arm/v6)
    and no specific platform was requested

Change-type: patch

Build tested on:
- RaspberryPi fleet using builders
- RaspberryPi Zero local push
- Orin fleet using builders