### PR TITLE
module: Fix x86 build

### DIFF
--- a/module/Dockerfile.template
+++ b/module/Dockerfile.template
@@ -11,7 +11,8 @@ RUN apk add --no-cache \
     openssl-dev \
     bc \
     wget \
-    bash
+    bash \
+    linux-headers
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
We've recently switched from a Ubuntu base image to an Alpine one. While that fixed the build for RaspberryPi and caused no regression for aarch64, it makes the build fail on x86 with:

    ./include/uapi/linux/types.h:5:10: fatal error: asm/types.h: No such file or directory

We now install the linux-headers package to fix the above build failure.

Change-type: patch

Tested with local push on:
- raspberry-pi
- genericx86-64-ext
- generic-amd64
- Jetson Orin Nano