### PR TITLE
module/workarounds: Drop unnecessary Beagle workaround

### DIFF
--- a/module/workarounds.sh
+++ b/module/workarounds.sh
@@ -24,11 +24,6 @@ if [[ "$device" == asus-tinker* ]] ; then
 	fi
 fi
 
-if [[ "$device" == beagle* ]] ; then
-	echo Workaround bbb
-	wget https://raw.githubusercontent.com/beagleboard/linux/4.14/arch/arm/kernel/module.lds -O "$PWD"/arch/arm/kernel/module.lds
-fi
-
 if [[ "$device" == ts4900 ]] ; then
 	echo Workaround ts4900
 	# Workaround for the ts4900 to deal with unknown relocation error


### PR DESCRIPTION
This workaround was for an older kernel version. As of today, removing this portion of code fixes the build for Beagle Black

Change-type: patch